### PR TITLE
Call interpreters with a login shell env to fix "command not found" on macOS

### DIFF
--- a/pycript/execution.py
+++ b/pycript/execution.py
@@ -1,24 +1,31 @@
 import subprocess
-from .gui import logerrors
 import os
+import sys
+from .gui import logerrors
 def get_login_shell_env():
-    # Determine the user's login shell
-    shell = os.environ.get('SHELL', '/bin/sh')
+    if sys.platform == "win32":
+        return os.environ.copy()
+    try:
+        # Determine the user's login shell
+        shell = os.environ.get('SHELL', '/bin/sh')
 
-    # Run the login shell and echo the environment
-    cmd = [shell, '-l', '-c', 'env']
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        # Run the login shell and echo the environment
+        cmd = [shell, '-l', '-c', 'env']
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
 
-    # Parse the output into a dictionary
-    env = {}
-    for line in proc.stdout:
-        line = line.decode('utf-8').strip()
-        if '=' in line:
-            key, value = line.split('=', 1)
-            env[key] = value
+        # Parse the output into a dictionary
+        env = {}
+        for line in proc.stdout:
+            line = line.decode('utf-8').strip()
+            if '=' in line:
+                key, value = line.split('=', 1)
+                env[key] = value
 
-    proc.wait()
-    return env
+        proc.wait()
+        return env
+    except Exception as e:
+        logerrors(str(e))
+        return os.environ.copy()
 
 login_env = get_login_shell_env()
 

--- a/pycript/execution.py
+++ b/pycript/execution.py
@@ -1,5 +1,26 @@
 import subprocess
 from .gui import logerrors
+import os
+def get_login_shell_env():
+    # Determine the user's login shell
+    shell = os.environ.get('SHELL', '/bin/sh')
+
+    # Run the login shell and echo the environment
+    cmd = [shell, '-l', '-c', 'env']
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+
+    # Parse the output into a dictionary
+    env = {}
+    for line in proc.stdout:
+        line = line.decode('utf-8').strip()
+        if '=' in line:
+            key, value = line.split('=', 1)
+            env[key] = value
+
+    proc.wait()
+    return env
+
+login_env = get_login_shell_env()
 
 def execute_command(selectedlang, path, data, headervalue=None):
     try:
@@ -22,6 +43,7 @@ def execute_command(selectedlang, path, data, headervalue=None):
         process = subprocess.Popen(
             command_str,
             shell=True,
+            env=login_env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True


### PR DESCRIPTION
This is to fix https://github.com/Anof-cyber/PyCript/issues/8, where the extension does not work on macOS. That issue is caused by the Popen call in `execution.py` having for whatever reason a very restricted `PATH` var. This pull request fixes it by executing `env` under a login shell once at init, and then passing that environment to all subsequent Popen calls to `python`, `node`, or `java`, so Popen can find them.